### PR TITLE
Add rich-click

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,15 @@ from setuptools import find_packages, setup  # type: ignore
 
 version = "0.0.3"
 
-requirements = ["earthengine-api", "rich", "humanize", "notify-py", "requests", "click"]
+requirements = [
+    "earthengine-api",
+    "rich",
+    "humanize",
+    "notify-py",
+    "requests",
+    "click",
+    "rich-click>1.0.2",
+]
 test_requirements = ["pytest"]
 dev_requirements = [
     "pre-commit",

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ requirements = [
     "notify-py",
     "requests",
     "click",
-    "rich-click>1.0.2",
+    "rich-click>=1.2.1",
 ]
 test_requirements = ["pytest"]
 dev_requirements = [

--- a/taskee/cli/cli.py
+++ b/taskee/cli/cli.py
@@ -1,11 +1,17 @@
 from typing import Tuple
 
-import click  # type: ignore
+import rich_click as click  # type: ignore
 
 from taskee import events
 from taskee.cli.commands import dashboard, log, tasks, test
 from taskee.notifiers import notifier
 from taskee.taskee import Taskee
+
+# import click
+
+
+click.rich_click.SHOW_ARGUMENTS = True
+click.rich_click.USE_MARKDOWN = True
 
 version = "0.0.3"
 modes = {"log": log.start, "dashboard": dashboard.start}
@@ -14,19 +20,22 @@ modes = {"log": log.start, "dashboard": dashboard.start}
 @click.group()
 @click.version_option(version, prog_name="taskee")
 def taskee() -> None:
-    """Monitor Earth Engine tasks and send notifications when they change states.
+    """
+    Monitor Earth Engine tasks and send notifications when they change states.
 
-    \b
-    Examples
-        $ taskee test
-        $ taskee tasks
-        $ taskee start log
-        $ taskee start dashboard failed completed -n pushbullet -i 0.5
+    **Examples**
+
+    ```bash
+    $ taskee test
+    $ taskee tasks
+    $ taskee start log
+    $ taskee start dashboard failed completed -n pushbullet -i 0.5
+    ```
     """
     return
 
 
-@taskee.command(name="start")
+@taskee.command(name="start", short_help="Start running the notification system.")
 @click.argument("mode", nargs=1, type=click.Choice(choices=modes.keys()))
 @click.argument(
     "watch_for",
@@ -59,13 +68,16 @@ def start_command(
     notifiers: Tuple[str, ...],
     interval_mins: float,
 ) -> None:
-    """Start running the notification system. Select a mode (default native)
+    """
+    Start running the notification system. Select a mode
     and one or more event types to watch for (or all).
 
-    \b
-    Examples
-        $ taskee start dashboard failed completed -n pushbullet -i 5
-        $ taskee start log all
+    **Examples**
+
+    ```bash
+    $ taskee start dashboard failed completed -n pushbullet -i 5
+    $ taskee start log all
+    ```
     """
     if len(watch_for) == 0:
         watch_for = ("completed", "failed", "error")
@@ -106,9 +118,11 @@ def test_command(notifiers: Tuple[str, ...]) -> None:
     """
     Send test notifications to selected notifiers (default native).
 
-    \b
-    Examples
-        $ taskee test -n all
+    **Examples**
+
+    ```bash
+    $ taskee test -n all
+    ```
     """
     test.test(notifiers)
 

--- a/taskee/cli/cli.py
+++ b/taskee/cli/cli.py
@@ -7,9 +7,6 @@ from taskee.cli.commands import dashboard, log, tasks, test
 from taskee.notifiers import notifier
 from taskee.taskee import Taskee
 
-# import click
-
-
 click.rich_click.SHOW_ARGUMENTS = True
 click.rich_click.USE_MARKDOWN = True
 
@@ -21,8 +18,9 @@ modes = {"log": log.start, "dashboard": dashboard.start}
 @click.version_option(version, prog_name="taskee")
 def taskee() -> None:
     """
-    Monitor Earth Engine tasks and send notifications when they change states.
-
+    Monitor Earth Engine tasks and send notifications when they change states.  
+    \
+    
     **Examples**
 
     ```bash
@@ -71,7 +69,8 @@ def start_command(
     """
     Start running the notification system. Select a mode
     and one or more event types to watch for (or all).
-
+    \
+    
     **Examples**
 
     ```bash
@@ -117,7 +116,8 @@ def tasks_command() -> None:
 def test_command(notifiers: Tuple[str, ...]) -> None:
     """
     Send test notifications to selected notifiers (default native).
-
+    \
+    
     **Examples**
 
     ```bash

--- a/taskee/notifiers/pushbullet.py
+++ b/taskee/notifiers/pushbullet.py
@@ -2,7 +2,7 @@ import configparser
 from typing import TYPE_CHECKING, Union
 
 from requests.exceptions import ConnectionError
-from rich.prompt import Prompt  # type: ignore
+from rich.prompt import Prompt
 
 from taskee.notifiers.notifier import Notifier
 from taskee.utils import config_path


### PR DESCRIPTION
Close #6 by using `rich-click` to improve formatting of command help strings.

An issue with command short help strings in `rich-click` was fixed by ewels/rich-click@5e0b8c5b6c6458c0bf036e6cde371abd18b6f596 but has not been released yet, so this will not be merged until that fix is released.