### PR TITLE
Handle unknown operation state and types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ all = "pytest . {args}"
 cov = "pytest . --cov=src/taskee {args}"
 
 [tool.ruff]
-select = ["E", "I", "F", "B", "FA", "UP", "PT", "Q", "RET", "SIM", "PERF"]
+select = ["E", "I", "F", "B", "FA", "UP", "PT", "Q", "RET", "SIM", "PERF", "ERA"]
 ignore = ["PERF203"]
 fix = true
 show-fixes = true

--- a/src/taskee/cli/commands/dashboard.py
+++ b/src/taskee/cli/commands/dashboard.py
@@ -14,7 +14,7 @@ from rich.table import Table
 from rich.text import Text
 
 from taskee.cli.commands.tasks import create_task_table
-from taskee.cli.styles import STYLES
+from taskee.cli.styles import get_style
 from taskee.taskee import Taskee
 
 if TYPE_CHECKING:
@@ -149,7 +149,7 @@ class _Dashboard:
 
         for event in tuple(self.event_log)[:max_events]:
             event_time = humanize.naturaltime(event.time)
-            event_style = STYLES[event.__class__]
+            event_style = get_style(event.__class__)
             event_name = event.__class__.__name__.replace("Event", "")
             muted_style = "[dim]" if event.__class__ not in self.t.watch_for else ""
             t.add_row(

--- a/src/taskee/cli/commands/log.py
+++ b/src/taskee/cli/commands/log.py
@@ -7,7 +7,7 @@ import time
 from rich.logging import RichHandler
 from rich.status import Status
 
-from taskee.cli.styles import STYLES
+from taskee.cli.styles import get_style
 from taskee.operation import FINISHED_OPERATION_STATES
 from taskee.taskee import Taskee
 
@@ -50,7 +50,7 @@ def start(
                     message += f" [dim]({len(t.active_tasks)} tasks remaining)[/]"
 
                 muted_style = "[dim]" if event.__class__ not in t.watch_for else ""
-                style = STYLES[event.__class__]
+                style = get_style(event.__class__)
                 logger.info(
                     f"[{style.color}]{style.emoji} {event.__class__.__name__}[/]:"
                     f" {muted_style}{message}"

--- a/src/taskee/cli/commands/tasks.py
+++ b/src/taskee/cli/commands/tasks.py
@@ -5,7 +5,7 @@ import rich
 from rich import box
 from rich.table import Table
 
-from taskee.cli.styles import STYLES
+from taskee.cli.styles import get_style
 from taskee.operation import ACTIVE_OPERATION_STATES, Operation
 
 
@@ -33,7 +33,7 @@ def create_task_table(tasks: tuple[Operation, ...], max_tasks: int) -> Table:
         state = task.metadata.state.value
         eecus = task.metadata.batchEecuUsageSeconds
 
-        state_style = STYLES[state]
+        state_style = get_style(state)
         dim_style = "[dim]" if state not in ACTIVE_OPERATION_STATES else ""
         time_created = humanize.naturaltime(task.metadata.createTime)
         time_elapsed = humanize.naturaldelta(task.time_elapsed)

--- a/src/taskee/cli/styles.py
+++ b/src/taskee/cli/styles.py
@@ -40,6 +40,7 @@ STYLES: Mapping[Any, Style] = {
     OperationState.RUNNING: Style(color=Color.INFO.value, emoji="🔧"),
 }
 
+
 def get_style(obj: Any) -> Style:
     """Get the style for an object."""
     return STYLES.get(obj, Style(color=Color.INFO.value, emoji="❓"))

--- a/src/taskee/cli/styles.py
+++ b/src/taskee/cli/styles.py
@@ -39,3 +39,7 @@ STYLES: Mapping[Any, Style] = {
     OperationState.PENDING: Style(color=Color.INFO.value, emoji="⏳"),
     OperationState.RUNNING: Style(color=Color.INFO.value, emoji="🔧"),
 }
+
+def get_style(obj: Any) -> Style:
+    """Get the style for an object."""
+    return STYLES.get(obj, Style(color=Color.INFO.value, emoji="❓"))

--- a/src/taskee/operation.py
+++ b/src/taskee/operation.py
@@ -7,8 +7,10 @@ from typing import Any, Union
 from pydantic import BaseModel, ConfigDict
 
 from taskee import events
+from taskee.utils import fallback_enum
 
 
+@fallback_enum("UNKNOWN")
 class OperationState(str, Enum):
     PENDING = "PENDING"
     RUNNING = "RUNNING"
@@ -18,11 +20,15 @@ class OperationState(str, Enum):
     CANCELLED = "CANCELLED"
 
 
+@fallback_enum("UNKNOWN")
 class OperationType(str, Enum):
     EXPORT_FEATURES = "EXPORT_FEATURES"
     EXPORT_IMAGE = "EXPORT_IMAGE"
     EXPORT_VIDEO = "EXPORT_VIDEO"
-    UNKNOWN = "UNKNOWN"
+    EXPORT_TILES = "EXPORT_TILES"
+    INGEST = "INGEST"
+    INGEST_IMAGE = "INGEST_IMAGE"
+    INGEST_TABLE = "INGEST_TABLE"
 
 
 class OperationStage(BaseModel):
@@ -45,12 +51,12 @@ class OperationMetadata(BaseModel):
     """Metadata about an Operation."""
 
     state: OperationState
+    type: OperationType
     description: str
     createTime: datetime
     updateTime: datetime
     startTime: datetime
     endTime: Union[datetime, None] = None
-    type: OperationType = OperationType.UNKNOWN
     attempt: int = 1
     progress: float = 0.0
     stages: Union[tuple[OperationStage, ...], None] = None

--- a/src/taskee/utils.py
+++ b/src/taskee/utils.py
@@ -1,6 +1,7 @@
 import difflib
 import os
-from enum import EnumMeta
+from enum import Enum, EnumMeta
+from typing import Any
 
 CONFIG_PATH = os.path.expanduser("~/.config/taskee.ini")
 
@@ -20,3 +21,68 @@ class SuggestionEnumMeta(EnumMeta):
                 msg += f" Did you mean '{close_match[0]}'?"
 
             raise KeyError(msg) from None
+
+
+# def fallback_enum(name: str="UNKNOWN", fallback: Any="UNKNOWN") -> Enum:
+#     """An enum decorator that falls back to a default value for invalid members.
+    
+#     Parameters
+#     ----------
+#     name : str
+#         The name of the fallback member.
+#     fallback : Any
+#         The value of the fallback member. The type of this value should match the enum
+#         type.
+#     """
+
+#     def _fallback_enum(enumeration: Enum) -> Enum:
+#         print(enumeration)
+#         @classmethod
+#         def _get_fallback_member(cls: Enum, _: Any) -> Enum:
+#             member_cls = type(fallback)
+#             member = member_cls.__new__(cls, fallback)
+#             member._name_ = name
+#             member._value_ = fallback
+
+#             return member
+
+#         if not isinstance(fallback, enumeration._member_type_):
+#             raise TypeError(
+#                 "Fallback value must match the enum type. "
+#                 f"Expected {enumeration._member_type_} but got {type(fallback)}."
+#             )
+#         enumeration._missing_ = _get_fallback_member
+#         return enumeration
+
+#     return _fallback_enum
+        
+def fallback_enum(fallback: Any, name: str="UNKNOWN") -> Enum:
+    """An enum decorator that falls back to a default value for invalid members.
+    
+    Parameters
+    ----------
+    fallback : Any
+        The value of the fallback member. The type of this value must match the enum
+        type.
+    name : str
+        The name of the fallback member.
+    """
+    def _fallback_enum(enumeration: Enum) -> Enum:
+        @classmethod
+        def _get_fallback_member(cls: Enum, _: Any) -> Enum:
+            member_cls = type(fallback)
+            member = member_cls.__new__(cls, fallback)
+            member._name_ = name
+            member._value_ = fallback
+
+            return member
+
+        if not isinstance(fallback, enumeration._member_type_):
+            raise TypeError(
+                "Fallback value must match the enum type. "
+                f"Expected {enumeration._member_type_} but got {type(fallback)}."
+            )
+        enumeration._missing_ = _get_fallback_member
+        return enumeration
+
+    return _fallback_enum

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -249,6 +249,7 @@ def test_tasks_truncates(cli, mock_task_list):
     assert "..." in result.output
     assert "mock_succeeded_task" not in result.output
 
+
 def test_tasks_unknown_state(cli):
     """The `task` command should handle unknown task states."""
     unexpected_op = MockOperation(description="unexpected_task", state="Ddf!sD?sdfl")

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -1,0 +1,9 @@
+from .mock_operation import MockOperation
+
+
+def test_operation_with_unknown_type_and_state():
+    """Operations with unrecognized states and types should fall back to UNKNOWN."""
+    op = MockOperation(state="MYSTERY_STATE", type="UNEXPECTED_NEW_TYPE")
+
+    assert op.metadata.state == "UNKNOWN"
+    assert op.metadata.type == "UNKNOWN"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,7 @@ def test_suggestion_enum():
     with pytest.raises(KeyError, match=re.escape(msg)):
         TestEnum["CC"]
 
+
 def test_fallback_enum():
     @fallback_enum(fallback="UNKNOWN")
     class TestStrEnum(str, Enum):
@@ -28,6 +29,7 @@ def test_fallback_enum():
     assert TestStrEnum("D") == "UNKNOWN"
 
     with pytest.raises(TypeError, match="value must match the enum type"):
+
         @fallback_enum(fallback=1)
         class TestStrEnum(str, Enum):
             A = "A"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,15 +3,13 @@ from enum import Enum
 
 import pytest
 
-from taskee.utils import SuggestionEnumMeta
+from taskee.utils import SuggestionEnumMeta, fallback_enum
 
 
 def test_suggestion_enum():
     """Test that SuggestionEnumMeta raises with suggestions."""
 
     class TestEnum(Enum, metaclass=SuggestionEnumMeta):
-        """A test enum."""
-
         A = 1
         B = 2
         C = 3
@@ -19,3 +17,19 @@ def test_suggestion_enum():
     msg = "TestEnum 'CC' not in ['A', 'B', 'C']. Did you mean 'C'?"
     with pytest.raises(KeyError, match=re.escape(msg)):
         TestEnum["CC"]
+
+def test_fallback_enum():
+    @fallback_enum(fallback="UNKNOWN")
+    class TestStrEnum(str, Enum):
+        A = "A"
+        B = "B"
+        C = "C"
+
+    assert TestStrEnum("D") == "UNKNOWN"
+
+    with pytest.raises(TypeError, match="value must match the enum type"):
+        @fallback_enum(fallback=1)
+        class TestStrEnum(str, Enum):
+            A = "A"
+            B = "B"
+            C = "C"


### PR DESCRIPTION
Closes #17 

Unrecognized states and types will now fall back to "UNKNOWN" instead of failing pydantic validation. Tests were added to confirm behavior, and the CLI styles were updated to include a fallback style.