### PR TITLE
Report task runtime

### DIFF
--- a/src/taskee/cli/commands/tasks.py
+++ b/src/taskee/cli/commands/tasks.py
@@ -26,8 +26,8 @@ def create_task_table(tasks: tuple[Operation, ...], max_tasks: int) -> Table:
     t.add_column("State", justify="right")
     t.add_column("Description", justify="left")
     t.add_column("Created", justify="right")
-    t.add_column("Elapsed", justify="right")
-    t.add_column("EECUs", justify="center")
+    t.add_column("Runtime", justify="right")
+    t.add_column("EECUs", justify="right")
 
     for task in tasks[:max_tasks]:
         state = task.metadata.state.value
@@ -35,15 +35,15 @@ def create_task_table(tasks: tuple[Operation, ...], max_tasks: int) -> Table:
 
         state_style = get_style(state)
         dim_style = "[dim]" if state not in ACTIVE_OPERATION_STATES else ""
-        time_created = humanize.naturaltime(task.metadata.createTime)
-        time_elapsed = humanize.naturaldelta(task.time_elapsed)
-        eecus_str = "-" if not eecus else f"{eecus:.0f}"
+        time_since_creation = humanize.naturaltime(task.time_since_creation)
+        runtime = humanize.naturaldelta(task.runtime) if task.runtime else "-"
+        eecus_str = "-" if not eecus else f"{eecus:,.0f}"
 
         t.add_row(
             f"[{state_style.color}]{state}[/] {state_style.emoji}",
             f"{dim_style}{task.metadata.description}",
-            f"{dim_style}{time_created}",
-            f"{dim_style}{time_elapsed}",
+            f"{dim_style}{time_since_creation}",
+            f"{dim_style}{runtime}",
             f"{dim_style}{eecus_str}",
         )
 

--- a/src/taskee/cli/styles.py
+++ b/src/taskee/cli/styles.py
@@ -33,7 +33,7 @@ STYLES: Mapping[Any, Style] = {
     events.CancelledEvent: Style(color=Color.ERROR.value, emoji="🪓"),
     # States
     OperationState.CANCELLING: Style(color=Color.ERROR.value, emoji="🚩"),
-    OperationState.CANCELLED: Style(color=Color.ERROR.value, emoji="✖️"),
+    OperationState.CANCELLED: Style(color=Color.ERROR.value, emoji="🚫"),
     OperationState.SUCCEEDED: Style(color=Color.SUCCESS.value, emoji="✅"),
     OperationState.FAILED: Style(color=Color.ERROR.value, emoji="❌"),
     OperationState.PENDING: Style(color=Color.INFO.value, emoji="⏳"),

--- a/src/taskee/events.py
+++ b/src/taskee/events.py
@@ -50,7 +50,7 @@ class FailedEvent(_TaskEvent):
     @property
     def message(self) -> str:
         error = self.task.error.message if self.task.error else "Unknown"
-        elapsed = humanize.naturaldelta(self.task.time_elapsed)
+        elapsed = humanize.naturaldelta(self.task.runtime)
         return (
             f"Task '{self.task.metadata.description}' failed after {elapsed} "
             f"with error '{error}'."
@@ -64,11 +64,11 @@ class CompletedEvent(_TaskEvent):
 
     @property
     def message(self) -> str:
-        elapsed = humanize.naturaldelta(self.task.time_elapsed)
+        elapsed = humanize.naturaldelta(self.task.runtime)
         eecus = self.task.metadata.batchEecuUsageSeconds
         return (
             f"Task '{self.task.metadata.description}' completed successfully! "
-            f"It ran for {elapsed} and used {eecus:.2f} EECU-seconds."
+            f"It ran for {elapsed} and used {eecus:,.0f} EECU-seconds."
         )
 
 

--- a/tests/mock_operation.py
+++ b/tests/mock_operation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import random
 import string
-from datetime import datetime
+from datetime import datetime, timezone
 
 from taskee.operation import (
     Operation,
@@ -58,7 +58,7 @@ class MockOperation(Operation):
             self.error = OperationError(code=1, message="Cancelled.")
 
         elif self.metadata.state == OperationState.PENDING:
-            self.metadata.startTime = datetime.utcfromtimestamp(0)
+            self.metadata.startTime = datetime.fromtimestamp(0, tz=timezone.utc)
 
         elif self.metadata.state == OperationState.SUCCEEDED:
             self.metadata.destinationUris = ("https://drive.google.com/",)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -22,7 +22,7 @@ def test_failed_event(mock_taskee, mock_pending_task):
 
     assert isinstance(event, FailedEvent)
 
-    expected_msg = "'mock_pending_task' failed after 10 minutes with error 'whoops'"
+    expected_msg = "'mock_pending_task' failed after a moment with error 'whoops'"
     assert expected_msg in event.message
 
 

--- a/tests/test_notifiers.py
+++ b/tests/test_notifiers.py
@@ -16,10 +16,10 @@ def test_native_notifier(mock_taskee, mock_running_task, mock_native_notifier):
         mock_taskee.update()
 
     mock_taskee.dispatch()
-
+    print(mock_running_task)
     assert mock_native_notifier.application_name == "taskee"
     assert mock_native_notifier.title == "Task Failed"
-    expected_msg = "'mock_running_task' failed after 10 minutes with error 'whoops'"
+    expected_msg = "'mock_running_task' failed after 9 minutes with error 'whoops'"
     assert expected_msg in mock_native_notifier.message
     mock_native_notifier.send.assert_called_once()
 
@@ -37,7 +37,7 @@ def test_pushbullet_notifier(mock_taskee, mock_running_task, mock_pushbullet_not
     mock_pushbullet_notifier.push_note.assert_called_once()
     title, msg = mock_pushbullet_notifier.push_note.call_args[0]
     assert title == "Task Failed"
-    assert "'mock_running_task' failed after 10 minutes with error 'uh oh'" in msg
+    assert "'mock_running_task' failed after 9 minutes with error 'uh oh'" in msg
 
 
 def test_pushbullet_uninstalled():


### PR DESCRIPTION
Close #22 by reporting the task's runtime instead of its time-since-creation in notifications. In CLI task tables, report time since creation instead of the creation time.